### PR TITLE
Update README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A sample app to get visual feedback from UIGestureRecognizer subclasses.
 
-Note: This app is meant for ipad only as it provides enough screen space to see both long press and pan gesture state machine side by side.
+Note: This app is meant for ipad only as it provides enough screen space to see both long press and pan gesture state machine side by side. But if you want to use the app in a smaller screen. You can change the radius and padding values in the file "GestureVisualizer.swift". For example, on iPhone 6s you can change the radius value from 40 to 30 and use landscape mode to see both long press and pan gesture state machine side by side.
 
 The view controller is already set up to create a few GestureVisualizers and stick them in the view.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # GestureVisualization
+
 A sample app to get visual feedback from UIGestureRecognizer subclasses.
+
+Note: This app is meant for ipad only as it provides enough screen space to see both long press and pan gesture state machine side by side.
 
 The view controller is already set up to create a few GestureVisualizers and stick them in the view.
 


### PR DESCRIPTION
- Added a note in the README.md file as the app is best viewed in iPad and not suited for iPhone. During my test I cannot see the two gesture diagrams long press and pan side by side in iPhone but I am able to see them in iPad properly.